### PR TITLE
Gradient had outdated direction syntax

### DIFF
--- a/src/locationfilter.css
+++ b/src/locationfilter.css
@@ -36,7 +36,7 @@ div.location-filter.button-container {
     background: -moz-linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
     background: -ms-linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
     background: -o-linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
-    background: linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
+    background: linear-gradient(to bottom, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
 }
 .leaflet-container div.location-filter.button-container a:hover {
     color: #263F1C;
@@ -47,7 +47,7 @@ div.location-filter.button-container {
     background: -moz-linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
     background: -ms-linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
     background: -o-linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
-    background: linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
+    background: linear-gradient(to bottom, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
 }
 
 .leaflet-container div.location-filter.button-container a.enable-button {
@@ -57,7 +57,7 @@ div.location-filter.button-container {
     background-image: url( img/filter-icon.png ), -moz-linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
     background-image: url( img/filter-icon.png ), -ms-linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
     background-image: url( img/filter-icon.png ), -o-linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
-    background-image: url( img/filter-icon.png ), linear-gradient(top, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
+    background-image: url( img/filter-icon.png ), linear-gradient(to bottom, rgba(218, 252, 205, 0.9) 0%, rgba(173, 226, 176, 0.9) 100%);
     background-repeat: no-repeat;
     background-position: left center;
 }
@@ -68,7 +68,7 @@ div.location-filter.button-container {
     background-image: url( img/filter-icon.png ), -moz-linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
     background-image: url( img/filter-icon.png ), -ms-linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
     background-image: url( img/filter-icon.png ), -o-linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
-    background-image: url( img/filter-icon.png ), linear-gradient(top, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
+    background-image: url( img/filter-icon.png ), linear-gradient(to bottom, rgba(245, 255, 240, 0.9) 0%, rgba(203, 228, 205, 0.9) 100%);
     background-repeat: no-repeat;
     background-position: left center;
 }


### PR DESCRIPTION
When using `linear-gradient` without prefix, the syntax is `to bottom` instead of `top`. See https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Cross-browser_gradients

I'm sure current browsers forgive using the syntax without `to`.

I saw/found the validation error when running

    npm install --global postcss-cli autoprefixer
    postcss --use autoprefixer *.css -d build/
    => leaflet.locationfilter.css:39:5: Gradient has outdated direction syntax. New syntax is like "to left" instead of "right".